### PR TITLE
Fix handling of empty paper search results

### DIFF
--- a/ai_scientist/generate_ideas.py
+++ b/ai_scientist/generate_ideas.py
@@ -416,6 +416,7 @@ def check_idea_novelty(
                 papers = search_for_papers(query, result_limit=10)
                 if papers is None:
                     papers_str = "No papers found."
+                    continue
 
                 paper_strings = []
                 for i, paper in enumerate(papers):


### PR DESCRIPTION
## Summary
- avoid iterating over `papers` when no search results are found
- leave `papers_str` as "No papers found." so the next iteration sees it

## Testing
- `python -m py_compile ai_scientist/generate_ideas.py`

------
https://chatgpt.com/codex/tasks/task_e_683f726b41c88321b905b7a56dd10481