### PR TITLE
Fix bug in novelty check when no papers found

### DIFF
--- a/ai_scientist/generate_ideas.py
+++ b/ai_scientist/generate_ideas.py
@@ -414,23 +414,24 @@ def check_idea_novelty(
                 ## SEARCH FOR PAPERS
                 query = json_output["Query"]
                 papers = search_for_papers(query, result_limit=10)
-                if papers is None:
+                if not papers:
                     papers_str = "No papers found."
-
-                paper_strings = []
-                for i, paper in enumerate(papers):
-                    paper_strings.append(
-                        """{i}: {title}. {authors}. {venue}, {year}.\nNumber of citations: {cites}\nAbstract: {abstract}""".format(
-                            i=i,
-                            title=paper["title"],
-                            authors=paper["authors"],
-                            venue=paper["venue"],
-                            year=paper["year"],
-                            cites=paper["citationCount"],
-                            abstract=paper["abstract"],
+                    papers = []
+                else:
+                    paper_strings = []
+                    for i, paper in enumerate(papers):
+                        paper_strings.append(
+                            """{i}: {title}. {authors}. {venue}, {year}.\nNumber of citations: {cites}\nAbstract: {abstract}""".format(
+                                i=i,
+                                title=paper["title"],
+                                authors=paper["authors"],
+                                venue=paper["venue"],
+                                year=paper["year"],
+                                cites=paper["citationCount"],
+                                abstract=paper["abstract"],
+                            )
                         )
-                    )
-                papers_str = "\n\n".join(paper_strings)
+                    papers_str = "\n\n".join(paper_strings)
 
             except Exception as e:
                 print(f"Error: {e}")


### PR DESCRIPTION
## Summary
- fix None handling in `check_idea_novelty`

## Testing
- `python -m py_compile ai_scientist/generate_ideas.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5b207acc8321bdf4fa96990f6a3b

## Summary by Sourcery

Bug Fixes:
- Replace `if papers is None` with a falsy check and default to an empty list when no papers are found to prevent runtime errors in `check_idea_novelty`