### PR TITLE
Fix inline code formatting

### DIFF
--- a/ai_scientist/perform_experiments.py
+++ b/ai_scientist/perform_experiments.py
@@ -21,7 +21,7 @@ For reference, the baseline results are as follows:
 
 {baseline_results}
 
-After you complete each change, we will run the command `python experiment.py --out_dir=run_i' where i is the run number and evaluate the results.
+After you complete each change, we will run the command `python experiment.py --out_dir=run_i` where i is the run number and evaluate the results.
 YOUR PROPOSED CHANGE MUST USE THIS COMMAND FORMAT, DO NOT ADD ADDITIONAL COMMAND LINE ARGS.
 You can then implement the next thing on your list."""
 
@@ -72,7 +72,7 @@ Someone else will be using `notes.txt` to perform a writeup on this in the futur
 Please include *all* relevant information for the writeup on Run {run_num}, including an experiment description and the run number. Be as verbose as necessary.
 
 Then, implement the next thing on your list.
-We will then run the command `python experiment.py --out_dir=run_{run_num + 1}'.
+We will then run the command `python experiment.py --out_dir=run_{run_num + 1}`.
 YOUR PROPOSED CHANGE MUST USE THIS COMMAND FORMAT, DO NOT ADD ADDITIONAL COMMAND LINE ARGS.
 If you are finished with experiments, respond with 'ALL_COMPLETED'."""
         return result.returncode, next_prompt


### PR DESCRIPTION
## Summary
- close inline `run_i` and `run_{run_num + 1}` code snippets with backticks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f726db1cc8321b9b1e9dc86ffa014

## Summary by Sourcery

Documentation:
- Close missing backticks around `python experiment.py --out_dir=run_i` and `python experiment.py --out_dir=run_{run_num + 1}` in docstrings