### PR TITLE
Fix LaTeX error message typo

### DIFF
--- a/ai_scientist/perform_writeup.py
+++ b/ai_scientist/perform_writeup.py
@@ -78,7 +78,7 @@ If duplicated, identify the best location for the section header and remove any 
         # Filter trivial bugs in chktex
         check_output = os.popen(f"chktex {writeup_file} -q -n2 -n24 -n13 -n1").read()
         if check_output:
-            prompt = f"""Please fix the following LaTeX errors in `template.tex` guided by the output of `chktek`:
+            prompt = f"""Please fix the following LaTeX errors in `template.tex` guided by the output of `chktex`:
 {check_output}.
 
 Make the minimal fix required and do not remove or change any packages.


### PR DESCRIPTION
## Summary
- correct "chktek" to "chktex" in writeup tool

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f726960f083218db9c87bbd759272

## Summary by Sourcery

Bug Fixes:
- Correct 'chktek' to 'chktex' in the LaTeX error prompt generated by the writeup tool.